### PR TITLE
v0.4 - commands unification, simplification of records

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ from project_generator.export import main
 main()
 ```
 
-Then just invoke run.py with arguments as you would if using the package. Somethign like: python run.py --version
+Then just invoke run.py with arguments as you would if using the package. Something like: python run.py --version
 
 There are examples in c0170 github, so check them out!
 

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -52,8 +52,8 @@ def main():
     # Parse Options
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-v', dest='verbosity', action='count', help='Increase the verbosity of the output (repeat for more verbose output)')
-    parser.add_argument('-q', dest='quietness', action='count', help='Decrease the verbosity of the output (repeat for more verbose output)')
+    parser.add_argument('-v', dest='verbosity', action='count', default=0, help='Increase the verbosity of the output (repeat for more verbose output)')
+    parser.add_argument('-q', dest='quietness', action='count', default=0, help='Decrease the verbosity of the output (repeat for more verbose output)')
 
     subparsers = parser.add_subparsers(help='commands')
 

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -24,51 +24,65 @@ from .builder import ProjectBuilder
 from .generator import ProjectGenerator
 from .settings import ProjectSettings
 
+def init(generator, settings, args):
+    logging.debug("Generating the records.")
+    generator.scrape_dir(args.board, args.folder)
+    sys.exit()
+
+def export(generator, settings, args):
+    if not args.tool:
+        args.tool = settings.DEFAULT_TOOL
+    if not args.file:
+        args.file = 'projects.yaml'
+    generator.set_toolchain(args)
+    projects, project_paths = generator.run(args)
+    if args.build:
+        ProjectBuilder(settings).run(args, projects, project_paths, root)
+
+def clean(generator, settings, args):
+    pass
+
 def main():
     logging.basicConfig(level=logging.INFO)
-    # Should be launched from root/tools but all scripts are referenced to root
+    # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
     os.chdir(root)
     logging.debug('This should be the project root: %s', os.getcwd())
 
     # Parse Options
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--file", help="YAML projects file.")
-    parser.add_argument("-p", "--project", help="Project to be generated.")
-    parser.add_argument(
+    subparsers = parser.add_subparsers(help='commands')
+
+    #
+    init_parser = subparsers.add_parser('init', help='Create a project record')
+    init_parser.add_argument('-b','--board', action='store', help='Board selection')
+    init_parser.add_argument('-f','--folder', action='store', help='Folder selection')
+    init_parser.set_defaults(func=init)
+
+    #
+    export_parser = subparsers.add_parser('export', help='Export a project record')
+    export_parser.add_argument("-f", "--file", help="YAML projects file.")
+    export_parser.add_argument("-p", "--project", help="Project to be generated.")
+    export_parser.add_argument(
         "-t", "--tool", help="Create project files for provided tool (uvision by default).")
-    parser.add_argument("-l", "--list", action="store_true",
-                      help="List projects defined in the project file.")
-    parser.add_argument(
-        "-b", "--build", action="store_true", help="Build defined projects.")
-    parser.add_argument(
-        "-i", "--init", help="Create records.")
+    export_parser.add_argument("-l", "--list", action="store_true",
+        help="List projects defined in the project file.")
+    export_parser.add_argument(
+        "-e", "--execute", action="store_true", help="Build defined projects.")
+    export_parser.set_defaults(func=export)
+
+    #
+    clean_parser = subparsers.add_parser('clean', help='Clean generated projects')
+    clean_parser.add_argument("-p", "--project", help="Specify which project to be removed")
+
     parser.add_argument("--version", action='version',
         version=pkg_resources.require("project_generator")[0].version, help="Display version.")
 
     args = parser.parse_args()
 
     settings = ProjectSettings()
-    if not args.tool:
-        args.tool = settings.DEFAULT_TOOL
-
     generator = ProjectGenerator(settings)
-    if args.init:
-        logging.debug("Generating the records.")
-        generator.scrape_dir(args.init)
-        sys.exit()
-
-    if not args.file:
-        args.file = 'projects.yaml'
-
-
-    # Generate projects
-    generator.set_toolchain(args)
-    projects, project_paths = generator.run(args)
-
-    # Build all exported projects
-    if args.build:
-        ProjectBuilder(settings).run(args, projects, project_paths, root)
+    args.func(generator, settings, args)
 
 if __name__ == '__main__':
     main()

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -36,11 +36,11 @@ def export(generator, settings, args):
         args.file = 'projects.yaml'
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
-    if args.build:
+    if args.execute:
         ProjectBuilder(settings).run(args, projects, project_paths, root)
 
 def clean(generator, settings, args):
-    pass
+    generator.clean(args)
 
 def main():
     logging.basicConfig(level=logging.INFO)
@@ -53,13 +53,13 @@ def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(help='commands')
 
-    #
+    # Init commands
     init_parser = subparsers.add_parser('init', help='Create a project record')
     init_parser.add_argument('-b','--board', action='store', help='Board selection')
-    init_parser.add_argument('-f','--folder', action='store', help='Folder selection')
+    init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
     init_parser.set_defaults(func=init)
 
-    #
+    # Export commands
     export_parser = subparsers.add_parser('export', help='Export a project record')
     export_parser.add_argument("-f", "--file", help="YAML projects file.")
     export_parser.add_argument("-p", "--project", help="Project to be generated.")
@@ -71,9 +71,12 @@ def main():
         "-e", "--execute", action="store_true", help="Build defined projects.")
     export_parser.set_defaults(func=export)
 
-    #
+    # Clean commands
     clean_parser = subparsers.add_parser('clean', help='Clean generated projects')
+    clean_parser.add_argument("-f", "--file", help="YAML projects file.")
     clean_parser.add_argument("-p", "--project", help="Specify which project to be removed")
+    clean_parser.add_argument(
+        "-t", "--tool", help="Create project files for provided tool (uvision by default).")
 
     parser.add_argument("--version", action='version',
         version=pkg_resources.require("project_generator")[0].version, help="Display version.")

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -46,7 +46,6 @@ def main():
     # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
     os.chdir(root)
-    logging.debug('This should be the project root: %s', os.getcwd())
 
     # Parse Options
     parser = argparse.ArgumentParser()
@@ -98,6 +97,7 @@ def main():
     logging_level = max(logging.DEBUG - (10*verbosity), 0)
     logging.basicConfig(level=logging_level)
 
+    logging.debug('This should be the project root: %s', os.getcwd())
     settings = ProjectSettings()
     generator = ProjectGenerator(settings)
     args.func(generator, settings, args, root)

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -42,6 +42,11 @@ def clean(generator, settings, args, root):
 def list_projects(generator, settings, args, root):
     generator.list_projects(generator.load_config(args))
 
+def load(generator, settings, args, root):
+    logging.info("Not supported currently")
+    pass
+
+
 def main():
     # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
@@ -85,6 +90,10 @@ def main():
     clean_parser.add_argument(
         "-t", "--tool", help="Create project files for provided tool (uvision by default)")
     clean_parser.set_defaults(func=clean)
+
+    load_parser = subparsers.add_parser('load', help='Load definition file')
+    load_parser.add_argument("-f", "--file", help="Definition file to be parsed")
+    load_parser.set_defaults(func=load)
 
     parser.add_argument("--version", action='version',
         version=pkg_resources.require("project_generator")[0].version, help="Display version")

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -26,11 +26,11 @@ from .settings import ProjectSettings
 
 def init(generator, settings, args, root):
     logging.debug("Generating the records.")
-    generator.scrape_dir(args.board, args.directory, args.sources)
+    generator.scrape_dir(args.board, args.directory, args.sources, root)
     sys.exit()
 
 def export(generator, settings, args, root):
-    generator.default_settings(args)
+    generator.default_settings(args, settings)
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
     if args.build:

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -30,10 +30,7 @@ def init(generator, settings, args):
     sys.exit()
 
 def export(generator, settings, args):
-    if not args.tool:
-        args.tool = settings.DEFAULT_TOOL
-    if not args.file:
-        args.file = 'projects.yaml'
+    generator.default_settings(args)
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
     if args.execute:
@@ -41,6 +38,9 @@ def export(generator, settings, args):
 
 def clean(generator, settings, args):
     generator.clean(args)
+
+def list(generator, settings, args):
+    generator.list_projects(generator.load_config(args))
 
 def main():
     logging.basicConfig(level=logging.DEBUG)
@@ -66,11 +66,14 @@ def main():
     export_parser.add_argument("-p", "--project", help="Project to be generated.")
     export_parser.add_argument(
         "-t", "--tool", help="Create project files for provided tool (uvision by default).")
-    export_parser.add_argument("-l", "--list", action="store_true",
-        help="List projects defined in the project file.")
     export_parser.add_argument(
         "-e", "--execute", action="store_true", help="Build defined projects.")
     export_parser.set_defaults(func=export)
+
+    # List commands
+    list_parser = subparsers.add_parser('list', help='List all projects')
+    list_parser.add_argument("-f", "--file", help="YAML projects file.")
+    list_parser.set_defaults(func=list_projects)
 
     # Clean commands
     clean_parser = subparsers.add_parser('clean', help='Clean generated projects')

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -91,8 +91,8 @@ def main():
         "-t", "--tool", help="Create project files for provided tool (uvision by default)")
     clean_parser.set_defaults(func=clean)
 
-    load_parser = subparsers.add_parser('load', help='Load definition file')
-    load_parser.add_argument("-f", "--file", help="Definition file to be parsed")
+    load_parser = subparsers.add_parser('load', help='Load definition files')
+    load_parser.add_argument("-dir", "--directory", help="Directory for pg definitions")
     load_parser.set_defaults(func=load)
 
     parser.add_argument("--version", action='version',

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -55,37 +55,38 @@ def main():
 
     # Init commands
     init_parser = subparsers.add_parser('init', help='Create a project record')
-    init_parser.add_argument('-b','--board', action='store', help='Board selection')
+    init_parser.add_argument('-bd','--board', action='store', help='Board definition')
     init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
-    init_parser.add_argument('-all','--all', action='store_true', help='List all files, otherwise only folders for sources.')
+    init_parser.add_argument(
+        '-s','--source', action='store_true', help='List all files, otherwise only folders for sources.')
     init_parser.set_defaults(func=init)
 
     # Export commands
     export_parser = subparsers.add_parser('export', help='Export a project record')
-    export_parser.add_argument("-f", "--file", help="YAML projects file.")
-    export_parser.add_argument("-p", "--project", help="Project to be generated.")
+    export_parser.add_argument("-f", "--file", help="YAML projects file")
+    export_parser.add_argument("-p", "--project", help="Project to be generated")
     export_parser.add_argument(
-        "-t", "--tool", help="Create project files for provided tool (uvision by default).")
+        "-t", "--tool", help="Create project files for provided tool (uvision by default)")
     export_parser.add_argument(
-        "-e", "--execute", action="store_true", help="Build defined projects.")
+        "-b", "--build", action="store_true", help="Build defined projects")
     export_parser.set_defaults(func=export)
 
     # List commands
     list_parser = subparsers.add_parser('list', help='List all projects')
-    list_parser.add_argument("-f", "--file", help="YAML projects file.")
+    list_parser.add_argument("-f", "--file", help="YAML projects file")
     list_parser.set_defaults(func=list_projects)
 
     # Clean commands
     clean_parser = subparsers.add_parser('clean', help='Clean generated projects')
-    clean_parser.add_argument("--all", help="All generated projects.")
-    clean_parser.add_argument("-f", "--file", help="YAML projects file.")
+    clean_parser.add_argument("--all", help="All generated projects")
+    clean_parser.add_argument("-f", "--file", help="YAML projects file")
     clean_parser.add_argument("-p", "--project", help="Specify which project to be removed")
     clean_parser.add_argument(
-        "-t", "--tool", help="Create project files for provided tool (uvision by default).")
+        "-t", "--tool", help="Create project files for provided tool (uvision by default)")
     clean_parser.set_defaults(func=clean)
 
     parser.add_argument("--version", action='version',
-        version=pkg_resources.require("project_generator")[0].version, help="Display version.")
+        version=pkg_resources.require("project_generator")[0].version, help="Display version")
 
     args = parser.parse_args()
 

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -26,7 +26,7 @@ from .settings import ProjectSettings
 
 def init(generator, settings, args, root):
     logging.debug("Generating the records.")
-    generator.scrape_dir(args.board, args.directory, args.sources, root)
+    generator.scrape_dir(args.target, args.directory, args.sources, root)
     sys.exit()
 
 def export(generator, settings, args, root):
@@ -62,7 +62,7 @@ def main():
 
     # Init commands
     init_parser = subparsers.add_parser('init', help='Create a project record')
-    init_parser.add_argument('-bd','--board', action='store', help='Board definition')
+    init_parser.add_argument('-tar','--target', action='store', help='Board definition')
     init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
     init_parser.add_argument(
         '-s','--sources', action='store_true', help='List all files, otherwise only folders for sources.')

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -53,6 +53,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-v', dest='verbosity', action='count', help='Increase the verbosity of the output (repeat for more verbose output)')
+    parser.add_argument('-q', dest='quietness', action='count', help='Decrease the verbosity of the output (repeat for more verbose output)')
 
     subparsers = parser.add_subparsers(help='commands')
 
@@ -94,7 +95,7 @@ def main():
     args = parser.parse_args()
 
     # set the verbosity
-    verbosity = args.verbosity
+    verbosity = args.verbosity - args.quietness
 
     logging_level = max(logging.DEBUG - (10*verbosity), 0)
     logging.setLevel(logging_level)

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+import sys
 import logging
 import pkg_resources
 
@@ -40,20 +41,28 @@ def main():
                       help="List projects defined in the project file.")
     parser.add_argument(
         "-b", "--build", action="store_true", help="Build defined projects.")
+    parser.add_argument(
+        "-i", "--init", help="Create records.")
     parser.add_argument("--version", action='version',
         version=pkg_resources.require("project_generator")[0].version, help="Display version.")
 
     args = parser.parse_args()
 
-    if not args.file:
-        args.file = 'projects.yaml'
-
     settings = ProjectSettings()
     if not args.tool:
         args.tool = settings.DEFAULT_TOOL
 
-    # Generate projects
     generator = ProjectGenerator(settings)
+    if args.init:
+        logging.debug("Generating the records.")
+        generator.scrape_dir(args.init)
+        sys.exit()
+
+    if not args.file:
+        args.file = 'projects.yaml'
+
+
+    # Generate projects
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
 

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -57,7 +57,7 @@ def main():
     init_parser = subparsers.add_parser('init', help='Create a project record')
     init_parser.add_argument('-b','--board', action='store', help='Board selection')
     init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
-    init_parser.add_argument('-all','--all', action='store', help='List all files, otherwise only folders for sources.')
+    init_parser.add_argument('-all','--all', action='store_true', help='List all files, otherwise only folders for sources.')
     init_parser.set_defaults(func=init)
 
     # Export commands

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -24,22 +24,22 @@ from .builder import ProjectBuilder
 from .generator import ProjectGenerator
 from .settings import ProjectSettings
 
-def init(generator, settings, args):
+def init(generator, settings, args, root):
     logging.debug("Generating the records.")
     generator.scrape_dir(args.board, args.directory, args.sources)
     sys.exit()
 
-def export(generator, settings, args):
+def export(generator, settings, args, root):
     generator.default_settings(args)
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
     if args.build:
         ProjectBuilder(settings).run(args, projects, project_paths, root)
 
-def clean(generator, settings, args):
+def clean(generator, settings, args, root):
     generator.clean(args)
 
-def list_projects(generator, settings, args):
+def list_projects(generator, settings, args, root):
     generator.list_projects(generator.load_config(args))
 
 def main():
@@ -100,7 +100,7 @@ def main():
 
     settings = ProjectSettings()
     generator = ProjectGenerator(settings)
-    args.func(generator, settings, args)
+    args.func(generator, settings, args, root)
 
 if __name__ == '__main__':
     main()

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -33,7 +33,7 @@ def export(generator, settings, args):
     generator.default_settings(args)
     generator.set_toolchain(args)
     projects, project_paths = generator.run(args)
-    if args.execute:
+    if args.build:
         ProjectBuilder(settings).run(args, projects, project_paths, root)
 
 def clean(generator, settings, args):
@@ -43,7 +43,6 @@ def list_projects(generator, settings, args):
     generator.list_projects(generator.load_config(args))
 
 def main():
-    logging.basicConfig(level=logging.INFO)
     # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
     os.chdir(root)
@@ -82,7 +81,6 @@ def main():
 
     # Clean commands
     clean_parser = subparsers.add_parser('clean', help='Clean generated projects')
-    clean_parser.add_argument("--all", help="All generated projects")
     clean_parser.add_argument("-f", "--file", help="YAML projects file")
     clean_parser.add_argument("-p", "--project", help="Specify which project to be removed")
     clean_parser.add_argument(
@@ -98,7 +96,7 @@ def main():
     verbosity = args.verbosity - args.quietness
 
     logging_level = max(logging.DEBUG - (10*verbosity), 0)
-    logging.setLevel(logging_level)
+    logging.basicConfig(level=logging_level)
 
     settings = ProjectSettings()
     generator = ProjectGenerator(settings)

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -43,7 +43,7 @@ def list_projects(generator, settings, args):
     generator.list_projects(generator.load_config(args))
 
 def main():
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
     os.chdir(root)
@@ -51,6 +51,9 @@ def main():
 
     # Parse Options
     parser = argparse.ArgumentParser()
+
+    parser.add_argument('-v', dest='verbosity', action='count', help='Increase the verbosity of the output (repeat for more verbose output)')
+
     subparsers = parser.add_subparsers(help='commands')
 
     # Init commands
@@ -89,6 +92,12 @@ def main():
         version=pkg_resources.require("project_generator")[0].version, help="Display version")
 
     args = parser.parse_args()
+
+    # set the verbosity
+    verbosity = args.verbosity
+
+    logging_level = max(logging.DEBUG - (10*verbosity), 0)
+    logging.setLevel(logging_level)
 
     settings = ProjectSettings()
     generator = ProjectGenerator(settings)

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -26,7 +26,7 @@ from .settings import ProjectSettings
 
 def init(generator, settings, args):
     logging.debug("Generating the records.")
-    generator.scrape_dir(args.board, args.directory, args.all)
+    generator.scrape_dir(args.board, args.directory, args.sources)
     sys.exit()
 
 def export(generator, settings, args):
@@ -39,7 +39,7 @@ def export(generator, settings, args):
 def clean(generator, settings, args):
     generator.clean(args)
 
-def list(generator, settings, args):
+def list_projects(generator, settings, args):
     generator.list_projects(generator.load_config(args))
 
 def main():
@@ -58,7 +58,7 @@ def main():
     init_parser.add_argument('-bd','--board', action='store', help='Board definition')
     init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
     init_parser.add_argument(
-        '-s','--source', action='store_true', help='List all files, otherwise only folders for sources.')
+        '-s','--sources', action='store_true', help='List all files, otherwise only folders for sources.')
     init_parser.set_defaults(func=init)
 
     # Export commands

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -26,7 +26,7 @@ from .settings import ProjectSettings
 
 def init(generator, settings, args):
     logging.debug("Generating the records.")
-    generator.scrape_dir(args.board, args.folder)
+    generator.scrape_dir(args.board, args.directory)
     sys.exit()
 
 def export(generator, settings, args):

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -43,7 +43,7 @@ def clean(generator, settings, args):
     generator.clean(args)
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     # Should be launched from project's root
     root = os.path.normpath(os.getcwd())
     os.chdir(root)
@@ -73,10 +73,12 @@ def main():
 
     # Clean commands
     clean_parser = subparsers.add_parser('clean', help='Clean generated projects')
+    clean_parser.add_argument("--all", help="All generated projects.")
     clean_parser.add_argument("-f", "--file", help="YAML projects file.")
     clean_parser.add_argument("-p", "--project", help="Specify which project to be removed")
     clean_parser.add_argument(
         "-t", "--tool", help="Create project files for provided tool (uvision by default).")
+    clean_parser.set_defaults(func=clean)
 
     parser.add_argument("--version", action='version',
         version=pkg_resources.require("project_generator")[0].version, help="Display version.")

--- a/project_generator/export.py
+++ b/project_generator/export.py
@@ -26,7 +26,7 @@ from .settings import ProjectSettings
 
 def init(generator, settings, args):
     logging.debug("Generating the records.")
-    generator.scrape_dir(args.board, args.directory)
+    generator.scrape_dir(args.board, args.directory, args.all)
     sys.exit()
 
 def export(generator, settings, args):
@@ -57,6 +57,7 @@ def main():
     init_parser = subparsers.add_parser('init', help='Create a project record')
     init_parser.add_argument('-b','--board', action='store', help='Board selection')
     init_parser.add_argument('-dir','--directory', action='store', help='Directory selection')
+    init_parser.add_argument('-all','--all', action='store', help='List all files, otherwise only folders for sources.')
     init_parser.set_defaults(func=init)
 
     # Export commands

--- a/project_generator/exporters/board_definitions.py
+++ b/project_generator/exporters/board_definitions.py
@@ -15,12 +15,12 @@
 class boardDefinitions():
 
     def get_board_definition(self, name, tool):
-        """ If a board is found, returns its definition for a tool, error otherwise. """
+        """ If a target is found, returns its definition for a tool, error otherwise. """
         try:
             return self.board_def[name][tool]
         except KeyError:
             raise RuntimeError(
-                "The board: %s was not recognized for %s. Please check board_def dictionary." % (name, tool))
+                "The target: %s was not recognized for %s. Please check board_def dictionary." % (name, tool))
 
     # This is a dictionary of supported boards. Each board defines tools and required data which
     # are retreived by tools generator. For gcc, it's core, for others it's mcu_def which is later

--- a/project_generator/exporters/coide.py
+++ b/project_generator/exporters/coide.py
@@ -89,7 +89,7 @@ class CoideExporter(Exporter):
 
         if not expanded_dic['mcu']:
             board = boardDefinitions()
-            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['board'], 'coide')
+            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['target'], 'coide')
         mcu_def_dic = self.definitions.get_mcu_definition(expanded_dic['mcu'])
         expanded_dic['coide_settings'].update(mcu_def_dic)
 

--- a/project_generator/exporters/exporter.py
+++ b/project_generator/exporters/exporter.py
@@ -1,4 +1,4 @@
-# Copyright 2014 0xc0170
+# Copyright 2014-2015 0xc0170
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project_generator/exporters/gccarm.py
+++ b/project_generator/exporters/gccarm.py
@@ -82,7 +82,7 @@ class MakefileGccArmExporter(Exporter):
         """ Processes misc options specific for GCC ARM, and run generator. """
         self.process_data_for_makefile(data, env_settings)
 
-        project_path, makefile = self.gen_file('makefile_gcc.tmpl', data, 'Makefile', "gcc_arm", data[
+        project_path, makefile = self.gen_file('makefile_gcc.tmpl', data, 'Makefile', "make_gcc_arm", data[
                                      'project_dir']['path'], data['project_dir']['name'])
         return project_path, [makefile]
 

--- a/project_generator/exporters/gccarm.py
+++ b/project_generator/exporters/gccarm.py
@@ -105,3 +105,7 @@ class MakefileGccArmExporter(Exporter):
         # change cortex-m0+ to cortex-m0plus
         if data['core'] == 'cortex-m0+':
             data['core'] = 'cortex-m0plus'
+
+        #set default values
+        if 'optimization_level' not in data:
+            data['optimization_level'] = self.optimization_options[0]

--- a/project_generator/exporters/gccarm.py
+++ b/project_generator/exporters/gccarm.py
@@ -97,7 +97,7 @@ class MakefileGccArmExporter(Exporter):
 
         if not data['core']:
             board = boardDefinitions()
-            data['core'] = board.get_board_definition(data['board'], 'gcc')
+            data['core'] = board.get_board_definition(data['target'], 'gcc')
         # gcc arm is funny about cortex-m4f.
         if data['core'] == 'cortex-m4f':
             data['core'] = 'cortex-m4'

--- a/project_generator/exporters/iar.py
+++ b/project_generator/exporters/iar.py
@@ -105,7 +105,7 @@ class IARExporter(Exporter):
 
         if not expanded_dic['mcu']:
             board = boardDefinitions()
-            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['board'], 'iar')
+            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['target'], 'iar')
         mcu_def_dic = self.definitions.get_mcu_definition(expanded_dic['mcu'])
         expanded_dic['iar_settings'].update(mcu_def_dic)
 

--- a/project_generator/exporters/uvision.py
+++ b/project_generator/exporters/uvision.py
@@ -170,4 +170,4 @@ class UvisionExporter(Exporter):
         return new_exe_path
  
     def supports_target(self, target):
-        return target in self.definitions.definitions.mcu_def
+        return target in self.definitions.mcu_def

--- a/project_generator/exporters/uvision.py
+++ b/project_generator/exporters/uvision.py
@@ -146,7 +146,7 @@ class UvisionExporter(Exporter):
 
         if not expanded_dic['mcu']:
             board = boardDefinitions()
-            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['board'], 'uvision')
+            expanded_dic['mcu'] = board.get_board_definition(expanded_dic['target'], 'uvision')
         mcu_def_dic = self.definitions.get_mcu_definition(expanded_dic['mcu'])
         self.append_mcu_def(expanded_dic, mcu_def_dic)
 

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -37,8 +37,10 @@ class ProjectGenerator:
 
     PROJECT_RECORD_TEMPLATE = {
         'common': {
+            'board' : ['add your board name here'],
             'include_paths' : [],
             'source_files' : [],
+            'linker_file' : [],
         }
     }
 
@@ -118,6 +120,9 @@ class ProjectGenerator:
                     path_from_root, filename = os.path.split(file)
                     if path_from_root not in common['common']['include_paths']:
                         common['common']['include_paths'].append(path_from_root)
+            elif k == 'sct' or k == 'ld':
+                for file in v:
+                    common['common']['linker_file'].append(file)
 
         source_list_path = os.getcwd()
         if not os.path.exists(source_list_path):

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -157,7 +157,9 @@ class ProjectGenerator:
     def load_config(self, options):
         logging.debug("Processing projects file.")
         project_file = open(options.file)
-        return yaml.load(project_file)
+        config = yaml.load(project_file)
+        project_file.close()
+        return config
 
     def default_settings(self, options):
         if not options.tool:
@@ -183,7 +185,6 @@ class ProjectGenerator:
             projects, projects_paths = self.process_all_projects(
                 config, options.tool, options.toolchain)
 
-        project_file.close()
         return (projects, projects_paths)
 
     def clean(self, options):
@@ -194,8 +195,7 @@ class ProjectGenerator:
             self.set_toolchain(options)
         else:
             options.toolchain = None
-        project_file = open(options.file)
-        config = yaml.load(project_file)
+        config = self.load_config(options)
         projects_paths = []
         if options.project:
             process_data = self.parse_project(config, options.project, options.tool, options.toolchain)
@@ -210,7 +210,7 @@ class ProjectGenerator:
             if process_data['project_dir']['name'] is '':
                 process_data['project_dir']['name'] = options.tool + '_' + process_data['name']
             projects_paths = join(process_data['project_dir']['path'], process_data['project_dir']['name'])
-        elif options.all:
+        else:
             projects = []
             for k, v in config['projects'].items():
                 projects.append(k)
@@ -230,9 +230,6 @@ class ProjectGenerator:
                     if generated_path is '':
                         generated_path = tools + '_' + process_data['name']
                     projects_paths.append(join(generated_dir, generated_path))
-        else:
-            logging.debug("Nothing specified, returning...")
-            return
 
         for project in projects_paths:
             if not os.path.exists(project):

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -187,6 +187,7 @@ class ProjectGenerator:
         return (projects, projects_paths)
 
     def clean(self, options):
+        # This function is a bit hacky, this needs a proper implementation
         if not options.file:
             options.file = 'projects.yaml'
         if options.tool or options.project:

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -15,6 +15,7 @@ import os
 import sys
 import yaml
 import logging
+import shutil
 
 from os.path import join, basename
 
@@ -47,8 +48,7 @@ class ProjectGenerator:
     def __init__(self, env_settings):
         self.env_settings = env_settings
 
-    def run_generator(self, dic, project, tool, toolchain):
-        """ Generates one project. """
+    def parse_project(self, dic, project, tool, toolchain):
         project_list = []
         yaml_files = _finditem(dic, project)
         if yaml_files:
@@ -68,7 +68,11 @@ class ProjectGenerator:
             yaml_parser_final.set_name(project)
         else:
             raise RuntimeError("Project: %s was not found." % project)
+        return process_data
 
+    def run_generator(self, dic, project, tool, toolchain):
+        """ Generates one project. """
+        process_data = self.parse_project(dic, project, tool, toolchain)
         logging.debug("Generating project: %s" % project)
         project_path = export(process_data, tool, self.env_settings)
         return project_path
@@ -171,3 +175,9 @@ class ProjectGenerator:
 
         project_file.close()
         return (projects, projects_paths)
+
+    def clean(self, options):
+        project_file = open(options.file)
+        config = yaml.load(project_file)
+        process_data = self.parse_project(dic, project, tool, toolchain)
+        pass

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -132,6 +132,9 @@ class ProjectGenerator:
                 for file in v:
                     common['common']['linker_file'].append(file)
 
+        if not common['common']['linker_file']:
+            common['common']['linker_file'].append('No linker file found')
+
         source_list_path = os.getcwd()
         if not os.path.exists(source_list_path):
             os.makedirs(source_list_path)
@@ -142,7 +145,7 @@ class ProjectGenerator:
     def list_projects(self, dic):
         """ Print all defined project. """
         for k, v in dic['projects'].items():
-            logging.info(k)
+            logging.info('project: %s' % k)
 
     def set_toolchain(self, options):
         try:
@@ -151,15 +154,19 @@ class ProjectGenerator:
             logging.error("The tool was find as unsupported: %s", options.tool)
             sys.exit(-1)
 
-    def run(self, options):
+    def load_config(self, options):
         logging.debug("Processing projects file.")
         project_file = open(options.file)
-        config = yaml.load(project_file)
+        return yaml.load(project_file)
 
-        if options.list:
-            logging.info("Projects defined in the %s" % options.file)
-            self.list_projects(config)
-            sys.exit()
+    def default_settings(self, options):
+        if not options.tool:
+            options.tool = settings.DEFAULT_TOOL
+        if not options.file:
+            options.file = 'projects.yaml'
+
+    def run(self, options):
+        config = self.load_config(options)
 
         # update enviroment variables
         self.env_settings.load_env_settings(config)

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -90,7 +90,7 @@ class ProjectGenerator:
         found = {x: [] for x in exts}  # lists of found files
         ignore = '.'
         if path:
-            directory = join(os.getcwd(),path)
+            directory = join(os.getcwd(), path)
         else:
             directory = join(os.getcwd(), 'source')
         for dirpath, dirnames, files in os.walk(directory):
@@ -107,6 +107,7 @@ class ProjectGenerator:
                 if ext in exts:
                     relpath = dirpath.replace(os.getcwd(), "")
                     found[ext].append(join(relpath, name))
+        # Create a directory which will be stored in the project.yaml file
         common = self.PROJECT_RECORD_TEMPLATE
         for k,v in found.items():
             if k == 's'  or k == 'c' or k == 'cpp':
@@ -115,25 +116,15 @@ class ProjectGenerator:
             elif k == 'h' or k == 'inc':
                 for file in v:
                     path_from_root, filename = os.path.split(file)
-                    common['common']['include_paths'].append(path_from_root)
+                    if path_from_root not in common['common']['include_paths']:
+                        common['common']['include_paths'].append(path_from_root)
 
-        common['common']['include_paths'] = set(common['common']['include_paths'])
-        common['common']['include_paths'] = list(common['common']['include_paths'])
-
-        # for search in found:
-        #     # Concatenate the result from the found dict
-        #     # logbody += "<< Results with the extension '%s' >>" % search
-        #     logbody += '\n\n%s\n\n' % '\n'.join(found[search])
-        # Write results to the logfile
         source_list_path = os.getcwd()
         if not os.path.exists(source_list_path):
             os.makedirs(source_list_path)
-        # target_path = join(source_list_path, 'project.yaml')
         logging.debug("Generating: %s" % source_list_path)
         with open('project.yaml', 'w') as outfile:
-            outfile.write( yaml.dump(common, default_flow_style=False) )
-        # with open(target_path, 'w') as logfile:
-        #     logfile.write('%s' % logbody)
+            outfile.write(yaml.dump(common, default_flow_style=False))
 
     def list_projects(self, dic):
         """ Print all defined project. """

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -139,7 +139,7 @@ class ProjectGenerator:
         if not os.path.exists(source_list_path):
             os.makedirs(source_list_path)
         logging.debug("Generating: %s" % source_list_path)
-        with open('project.yaml', 'w') as outfile:
+        with open('gen_project.yaml', 'w') as outfile:
             outfile.write(yaml.dump(common, default_flow_style=False))
 
     def list_projects(self, dic):

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -135,7 +135,7 @@ class ProjectGenerator:
         try:
             options.toolchain = self.TOOLCHAINS[options.tool]
         except KeyError:
-            logging.error("The tool was find as supported: %s", options.tool)
+            logging.error("The tool was find as unsupported: %s", options.tool)
             sys.exit(-1)
 
     def run(self, options):

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -39,7 +39,7 @@ class ProjectGenerator:
 
     PROJECT_RECORD_TEMPLATE = {
         'common': {
-            'board' : [],
+            'target' : [],
             'include_paths' : [],
             'source_files' : [],
             'linker_file' : [],
@@ -90,7 +90,8 @@ class ProjectGenerator:
                 self.run_generator(dic, project, tool, toolchain))
         return (projects, projects_paths)
 
-    def scrape_dir(self, board, path, gen_files, root):
+    def scrape_dir(self, target, path, gen_files, root):
+        """ Generates a record for given directory. """
         # recognized files
         exts = ['s', 'c', 'cpp', 'h', 'inc', 'sct', 'ld', 'lin']
         found = {x: [] for x in exts}  # lists of found files
@@ -115,7 +116,7 @@ class ProjectGenerator:
                     found[ext].append(join(relpath, name))
         # Create a directory which will be stored in the project.yaml file
         common = self.PROJECT_RECORD_TEMPLATE
-        common['common']['board'].append(board if board else 'No board given')
+        common['common']['target'].append(target if target else 'No target given')
         for k,v in found.items():
             if k == 's'  or k == 'c' or k == 'cpp':
                 for file in v:
@@ -155,6 +156,7 @@ class ProjectGenerator:
             sys.exit(-1)
 
     def load_config(self, options):
+        """ Load the project file. """
         logging.debug("Processing projects file.")
         project_file = open(options.file)
         config = yaml.load(project_file)

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -1,4 +1,4 @@
-# Copyright 2014 0xc0170
+# Copyright 2014-2015 0xc0170
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ class ProjectGenerator:
                     found[ext].append(join(relpath, name))
         # Create a directory which will be stored in the project.yaml file
         common = self.PROJECT_RECORD_TEMPLATE
-        common['common']['board'].append(board)
+        common['common']['board'].append(board if board else 'No board given')
         for k,v in found.items():
             if k == 's'  or k == 'c' or k == 'cpp':
                 for file in v:

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -90,9 +90,9 @@ class ProjectGenerator:
                 self.run_generator(dic, project, tool, toolchain))
         return (projects, projects_paths)
 
-    def scrape_dir(self, board, path, gen_files):
+    def scrape_dir(self, board, path, gen_files, root):
         # recognized files
-        exts = ['s', 'c', 'cpp', 'h', 'inc', 'sct', 'ld']
+        exts = ['s', 'c', 'cpp', 'h', 'inc', 'sct', 'ld', 'lin']
         found = {x: [] for x in exts}  # lists of found files
         ignore = '.'
         if path:
@@ -111,7 +111,7 @@ class ProjectGenerator:
                 ext = name.lower().rsplit('.', 1)[-1]
                 # Save the full name if ext matches
                 if ext in exts:
-                    relpath = dirpath.replace(os.getcwd(), "")
+                    relpath = os.path.relpath(dirpath, root)
                     found[ext].append(join(relpath, name))
         # Create a directory which will be stored in the project.yaml file
         common = self.PROJECT_RECORD_TEMPLATE
@@ -128,7 +128,7 @@ class ProjectGenerator:
                     path_from_root, filename = os.path.split(file)
                     if path_from_root not in common['common']['include_paths']:
                         common['common']['include_paths'].append(path_from_root)
-            elif k == 'sct' or k == 'ld':
+            elif k == 'sct' or k == 'ld' or k =='lin':
                 for file in v:
                     common['common']['linker_file'].append(file)
 
@@ -161,7 +161,7 @@ class ProjectGenerator:
         project_file.close()
         return config
 
-    def default_settings(self, options):
+    def default_settings(self, options, settings):
         if not options.tool:
             options.tool = settings.DEFAULT_TOOL
         if not options.file:

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -96,9 +96,9 @@ class ProjectGenerator:
         found = {x: [] for x in exts}  # lists of found files
         ignore = '.'
         if path:
-            directory = join(os.getcwd(), path)
+            directory = join(root, path)
         else:
-            directory = join(os.getcwd(), 'source')
+            directory = root
         for dirpath, dirnames, files in os.walk(directory):
             # Remove directories in ignore
             # directory names must match exactly!

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -90,7 +90,7 @@ class ProjectGenerator:
                 self.run_generator(dic, project, tool, toolchain))
         return (projects, projects_paths)
 
-    def scrape_dir(self, board, path):
+    def scrape_dir(self, board, path, gen_files):
         # recognized files
         exts = ['s', 'c', 'cpp', 'h', 'inc', 'sct', 'ld']
         found = {x: [] for x in exts}  # lists of found files
@@ -119,7 +119,10 @@ class ProjectGenerator:
         for k,v in found.items():
             if k == 's'  or k == 'c' or k == 'cpp':
                 for file in v:
-                    common['common']['source_files'].append(file)
+                    if gen_files:
+                        common['common']['source_files'].append(file)
+                    elif os.path.dirname(file) not in common['common']['source_files']:
+                        common['common']['source_files'].append(os.path.dirname(file))
             elif k == 'h' or k == 'inc':
                 for file in v:
                     path_from_root, filename = os.path.split(file)

--- a/project_generator/generator.py
+++ b/project_generator/generator.py
@@ -37,7 +37,7 @@ class ProjectGenerator:
 
     PROJECT_RECORD_TEMPLATE = {
         'common': {
-            'board' : ['add your board name here'],
+            'board' : [],
             'include_paths' : [],
             'source_files' : [],
             'linker_file' : [],
@@ -86,7 +86,7 @@ class ProjectGenerator:
                 self.run_generator(dic, project, tool, toolchain))
         return (projects, projects_paths)
 
-    def scrape_dir(self, path):
+    def scrape_dir(self, board, path):
         # recognized files
         exts = ['s', 'c', 'cpp', 'h', 'inc', 'sct', 'ld']
         found = {x: [] for x in exts}  # lists of found files
@@ -111,6 +111,7 @@ class ProjectGenerator:
                     found[ext].append(join(relpath, name))
         # Create a directory which will be stored in the project.yaml file
         common = self.PROJECT_RECORD_TEMPLATE
+        common['common']['board'].append(board)
         for k,v in found.items():
             if k == 's'  or k == 'c' or k == 'cpp':
                 for file in v:

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -1,4 +1,4 @@
-# Copyright 2014 0xc0170
+# Copyright 2014-2015 0xc0170
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -22,7 +22,7 @@ class YAML_parser:
         self.data = {
             'name': '',                 # project name
             'mcu' : '',
-            'board' : '',
+            'target' : '',
             'core': '',                 # core
             'linker_file': '',          # linker command file
             'include_paths': [],        # include paths
@@ -123,7 +123,7 @@ class YAML_parser:
         if project_dir:
             self.data['project_dir'].update(project_dir)
         self.data['core'] = _finditem(common_attributes, 'core')
-        self.data['board'] = _finditem(common_attributes, 'board')
+        self.data['target'] = _finditem(common_attributes, 'target')
         self.data['linker_file'] = _finditem(common_attributes, 'linker_file')
 
         # load all specific files
@@ -179,9 +179,9 @@ class YAML_parser:
             mcu = _finditem(dic, 'mcu')  # TODO fix naming
             if mcu:
                 self.data['mcu'] = mcu[0]
-            board = _finditem(dic, 'board')
-            if board:
-                self.data['board'] = board[0]
+            target = _finditem(dic, 'target')
+            if target:
+                self.data['target'] = target[0]
             project_dir = _finditem(dic, 'project_dir')
             if project_dir['name']:
                 self.data['project_dir']['name'] = project_dir['name'][0]

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -114,6 +114,7 @@ class YAML_parser:
             self.data['project_dir'].update(project_dir)
         self.data['core'] = _finditem(common_attributes, 'core')
         self.data['board'] = _finditem(common_attributes, 'board')
+        self.data['linker_file'] = _finditem(common_attributes, 'linker_file')
 
         # load all specific files
         specific_dic = {}

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+from os import listdir
+from os.path import isfile, join
 
 class YAML_parser:
 
@@ -82,10 +84,18 @@ class YAML_parser:
         self.data['include_paths'] = include_paths
 
     def find_source_files(self, common_attributes, group_name):
+        files = []
         try:
             for k, v in common_attributes.items():
                 if k == 'source_files':
-                    self.process_files(v, group_name)
+                    # Source directory can be either a directory or files
+                    for paths in v:
+                        if os.path.isdir(paths):
+                            files_in_dir = [ join(paths, f) for f in listdir(paths) if isfile(join(paths,f)) ]
+                            files += files_in_dir
+                        else:
+                            files = v
+                    self.process_files(files, group_name)
         except KeyError:
             pass
 

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
 class YAML_parser:
 
@@ -48,6 +49,9 @@ class YAML_parser:
             elif extension == 'cpp':
                 self.data['source_files_cpp'][group_name].append(source_file)
 
+            if os.path.dirname(source_file) not in self.data['source_paths']:
+                self.data['source_paths'].append(os.path.dirname(source_file))
+
     def find_group_name(self, common_attributes):
         """ Creates new dictionaries based on group_name """
         group_name = None
@@ -68,16 +72,13 @@ class YAML_parser:
     def find_paths(self, common_attributes):
         """ Find defined include and source paths """
         include_paths = []
-        source_paths = []
         try:
             for k, v in common_attributes.items():
-                if k == 'source_paths':
-                    source_paths = (v)
-                elif k == 'include_paths':
+                if k == 'include_paths':
                     include_paths = (v)
         except KeyError:
             pass
-        self.data['source_paths'] = source_paths
+
         self.data['include_paths'] = include_paths
 
     def find_source_files(self, common_attributes, group_name):

--- a/project_generator/yaml_parser.py
+++ b/project_generator/yaml_parser.py
@@ -171,6 +171,10 @@ class YAML_parser:
         if lib:
             self.data['source_files_lib'].append(lib)
 
+        # in case no include paths were defined, set them to source paths
+        if not self.data['include_paths']:
+            self.data['include_paths'] = self.data['source_paths']
+
         return self.data
 
     def parse_yaml_list(self, project_list):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='project_generator',
-    version='0.4-beta',
+    version='0.4',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal, Matthew Else',
     author_email='c0170@rocketmail.com, matthewelse1997@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='project_generator',
-    version='0.3.1',
+    version='0.4-beta',
     description='Project generators for various embedded tools (IDE). IAR, uVision, Makefile and many more in the roadmap!',
     author='Martin Kojtal, Matthew Else',
     author_email='c0170@rocketmail.com, matthewelse1997@gmail.com',


### PR DESCRIPTION
I'll need to reference couple of issues created recently, which should be resolved.

This is the new usage:

```
usage: project_generator-script.py [-h] [-v] [-q] [--version]
                                   {init,export,list,clean} ...

positional arguments:
  {init,export,list,clean}
                        commands
    init                Create a project record
    export              Export a project record
    list                List all projects
    clean               Clean generated projects

optional arguments:
  -h, --help            show this help message and exit
  -v                    Increase the verbosity of the output (repeat for more
                        verbose output)
  -q                    Decrease the verbosity of the output (repeat for more
                        verbose output)
  --version             Display version
```

There are new commands init, export, list and clean. Their subarguments are at https://github.com/0xc0170/project_generator/compare/dev_init_records?expand=1#diff-444de46b5300d2b854afb9b91a1767fcR59

Clean command is a bit complicated and will need simplification. Source_files can be directories from now on. If there is a file, it's taken, if it's a directory, all files withing that directory (no deeper) are taken.


I might look at the board definitions , to include it to this PR. Please review, test and report. I'll keep it open for a while, continue with local tests.

