### PR TITLE
Fix requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import os
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
+
+requirements = [str(requirement) for requirement in parse_requirements('requirements.txt')]
 
 setup(
     name='project_generator',
@@ -31,8 +34,6 @@ setup(
         ]
     },
 
-    install_requires=[
-        'pyyaml'
-    ],
+    install_requires = requirements,
     include_package_data = True,
 )


### PR DESCRIPTION
This now uses requirements.txt to get all of the requirements, which means that jinja2 is installed (as it should have been originally)