### PR TITLE
Debug msg for project dict and mcu tools definitions

### DIFF
--- a/project_generator/exporters/coide.py
+++ b/project_generator/exporters/coide.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import logging
 
 from os.path import basename, join, relpath, normpath
 
@@ -122,6 +123,7 @@ class CoideExporter(Exporter):
         if not mcu_def_dic:
              raise RuntimeError("Mcu definitions were not found for %s" % expanded_dic['target'])
         self.normalize_mcu_def(mcu_def_dic)
+        logging.debug("Mcu definitions: %s" % mcu_def_dic)
         expanded_dic['coide_settings'].update(mcu_def_dic)
 
         # Project file

--- a/project_generator/exporters/iar.py
+++ b/project_generator/exporters/iar.py
@@ -14,6 +14,7 @@
 
 from os.path import basename, join, relpath, normpath
 import copy
+import logging
 
 from .exporter import Exporter
 from .iar_definitions import IARDefinitions
@@ -133,6 +134,7 @@ class IAREWARMExporter(Exporter):
         if not mcu_def_dic:
              raise RuntimeError("Mcu definitions were not found for %s" % expanded_dic['target'])
         self.normalize_mcu_def(mcu_def_dic)
+        logging.debug("Mcu definitions: %s" % mcu_def_dic)
         expanded_dic['iar_settings'].update(mcu_def_dic)
 
         project_path, ewp = self.gen_file('iar.ewp.tmpl', expanded_dic, '%s.ewp' %

--- a/project_generator/exporters/uvision.py
+++ b/project_generator/exporters/uvision.py
@@ -14,6 +14,7 @@
 
 import copy
 import shutil
+import logging
 
 from os.path import basename, join, relpath, normpath
 
@@ -173,6 +174,7 @@ class UvisionExporter(Exporter):
         if not mcu_def_dic:
              raise RuntimeError("Mcu definitions were not found for %s" % expanded_dic['target'])
         self.normalize_mcu_def(mcu_def_dic)
+        logging.debug("Mcu definitions: %s" % mcu_def_dic)
         self.append_mcu_def(expanded_dic, mcu_def_dic)
 
         # set default build directory if unset

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -295,8 +295,10 @@ class Project:
         """export the project"""
         exporter = self.tools.get_value(tool, 'exporter')
 
+        proj_dic = self.generate_dict_for_tool(tool)
+        logging.debug("Project dict: %s" % proj_dic)
         project_path, project_files = export(exporter,
-            self.generate_dict_for_tool(tool), tool, self.workspace.settings)
+            proj_dic, tool, self.workspace.settings)
 
         self.project_path = project_path
         self.project_files = project_files


### PR DESCRIPTION
If debug logging is set, pgen will provide details about the project dictionary and mcu definitions. This should be helpful for reporting bugs or finding out why it fails. Like something important is missing in the exported project or exporting failed because a path for linker was not set.

An example of what we are adding
```
DEBUG:root:Project dict: {'core': '', 'source_files_lib': [], 'name': 'lpc1768_blinky', 'source_files_c': [{'default': [], 'lpc1768_cmsis': ['mbed\\libraries\\mbed\\targets\\cmsis\\TARGET_NXP\\TARGET_LPC176X\\cmsis_nvic.c', 'mbed\\libraries\\mbed\\targets\\cmsis\\TARGET_NXP\\TARGET_LPC176X\\system_LPC17xx.c'], 'lpc1768_hal': ['mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\analogin_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\analogout_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\can_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\ethernet_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\gpio_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\gpio_irq_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\i2c_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\pinmap.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\port_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\pwmout_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\rtc_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\serial_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\sleep.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\spi_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\us_ticker.c'], 'mbed_common': ['mbed\\libraries\\mbed\\common\\assert.c', 'mbed\\libraries\\mbed\\common\\board.c', 'mbed\\libraries\\mbed\\common\\error.c', 'mbed\\libraries\\mbed\\common\\exit.c', 'mbed\\libraries\\mbed\\common\\gpio.c', 'mbed\\libraries\\mbed\\common\\mbed_interface.c', 'mbed\\libraries\\mbed\\common\\pinmap_common.c', 'mbed\\libraries\\mbed\\common\\rtc_time.c', 'mbed\\libraries\\mbed\\common\\semihost_api.c', 'mbed\\libraries\\mbed\\common\\us_ticker_api.c', 'mbed\\libraries\\mbed\\common\\wait_api.c']}], 'source_paths': ['mbed\\libraries\\mbed\\common', 'mbed/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X', 'examples/blinky'], 'source_files_s': [{'default': [], 'lpc1768_cmsis': ['mbed/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/startup_LPC17xx.s'], 'lpc1768_hal': [], 'mbed_common': []}], 'misc': [{'Compile': {'OptimizationLevel': [4], 'UserEditCompiler': ['fno-common', 'fmessage-length=0', 'Wall', 'fno-strict-aliasing', 'fno-rtti', 'fno-exceptions', 'ffunction-sections', 'fdata-sections', 'std=gnu++98']}, 'Link': {'UserEditLinker': ['--specs=nano.specs', '-u _printf_float', '-u _scanf_float'], 'LinkedLibraries': ['stdc++', 'supc++', 'm', 'gcc', 'c', 'nosys']}}], 'source_files_cpp': [{'default': ['examples\\blinky\\main.cpp'], 'lpc1768_cmsis': [], 'lpc1768_hal': [], 'mbed_common': ['mbed\\libraries\\mbed\\common\\BusIn.cpp', 'mbed\\libraries\\mbed\\common\\BusInOut.cpp', 'mbed\\libraries\\mbed\\common\\BusOut.cpp', 'mbed\\libraries\\mbed\\common\\CallChain.cpp', 'mbed\\libraries\\mbed\\common\\CAN.cpp', 'mbed\\libraries\\mbed\\common\\Ethernet.cpp', 'mbed\\libraries\\mbed\\common\\FileBase.cpp', 'mbed\\libraries\\mbed\\common\\FileLike.cpp', 'mbed\\libraries\\mbed\\common\\FilePath.cpp', 'mbed\\libraries\\mbed\\common\\FileSystemLike.cpp', 'mbed\\libraries\\mbed\\common\\FunctionPointer.cpp', 'mbed\\libraries\\mbed\\common\\I2C.cpp', 'mbed\\libraries\\mbed\\common\\I2CSlave.cpp', 'mbed\\libraries\\mbed\\common\\InterruptIn.cpp', 'mbed\\libraries\\mbed\\common\\InterruptManager.cpp', 'mbed\\libraries\\mbed\\common\\LocalFileSystem.cpp', 'mbed\\libraries\\mbed\\common\\RawSerial.cpp', 'mbed\\libraries\\mbed\\common\\retarget.cpp', 'mbed\\libraries\\mbed\\common\\Serial.cpp', 'mbed\\libraries\\mbed\\common\\SerialBase.cpp', 'mbed\\libraries\\mbed\\common\\SPI.cpp', 'mbed\\libraries\\mbed\\common\\SPISlave.cpp', 'mbed\\libraries\\mbed\\common\\Stream.cpp', 'mbed\\libraries\\mbed\\common\\Ticker.cpp', 'mbed\\libraries\\mbed\\common\\Timeout.cpp', 'mbed\\libraries\\mbed\\common\\Timer.cpp', 'mbed\\libraries\\mbed\\common\\TimerEvent.cpp']}], 'macros': ['TARGET_LPC1768', 'TARGET_M3', 'TARGET_NXP', '__CORTEX_M3', '__MBED__=1', 'TOOLCHAIN_ARM_GCC'], 'include_paths': ['mbed\\libraries\\mbed\\api', 'mbed\\libraries\\mbed\\common', 'mbed\\libraries\\mbed/hal', 'mbed/libraries/mbed/targets/cmsis', 'mbed/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X', 'mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X', 'mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768', 'examples/blinky'], 'linker_file': 'mbed/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/LPC1768.ld', 'source_files': {'default': {'cpp': ['examples\\blinky\\main.cpp']}, 'lpc1768_cmsis': {'c': ['mbed\\libraries\\mbed\\targets\\cmsis\\TARGET_NXP\\TARGET_LPC176X\\cmsis_nvic.c', 'mbed\\libraries\\mbed\\targets\\cmsis\\TARGET_NXP\\TARGET_LPC176X\\system_LPC17xx.c'], 's': ['mbed/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC176X/TOOLCHAIN_GCC_ARM/startup_LPC17xx.s']}, 'lpc1768_hal': {'c': ['mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\analogin_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\analogout_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\can_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\ethernet_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\gpio_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\gpio_irq_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\i2c_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\pinmap.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\port_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\pwmout_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\rtc_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\serial_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\sleep.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\spi_api.c', 'mbed\\libraries\\mbed\\targets\\hal\\TARGET_NXP\\TARGET_LPC176X\\us_ticker.c']}, 'mbed_common': {'cpp': ['mbed\\libraries\\mbed\\common\\BusIn.cpp', 'mbed\\libraries\\mbed\\common\\BusInOut.cpp', 'mbed\\libraries\\mbed\\common\\BusOut.cpp', 'mbed\\libraries\\mbed\\common\\CallChain.cpp', 'mbed\\libraries\\mbed\\common\\CAN.cpp', 'mbed\\libraries\\mbed\\common\\Ethernet.cpp', 'mbed\\libraries\\mbed\\common\\FileBase.cpp', 'mbed\\libraries\\mbed\\common\\FileLike.cpp', 'mbed\\libraries\\mbed\\common\\FilePath.cpp', 'mbed\\libraries\\mbed\\common\\FileSystemLike.cpp', 'mbed\\libraries\\mbed\\common\\FunctionPointer.cpp', 'mbed\\libraries\\mbed\\common\\I2C.cpp', 'mbed\\libraries\\mbed\\common\\I2CSlave.cpp', 'mbed\\libraries\\mbed\\common\\InterruptIn.cpp', 'mbed\\libraries\\mbed\\common\\InterruptManager.cpp', 'mbed\\libraries\\mbed\\common\\LocalFileSystem.cpp', 'mbed\\libraries\\mbed\\common\\RawSerial.cpp', 'mbed\\libraries\\mbed\\common\\retarget.cpp', 'mbed\\libraries\\mbed\\common\\Serial.cpp', 'mbed\\libraries\\mbed\\common\\SerialBase.cpp', 'mbed\\libraries\\mbed\\common\\SPI.cpp', 'mbed\\libraries\\mbed\\common\\SPISlave.cpp', 'mbed\\libraries\\mbed\\common\\Stream.cpp', 'mbed\\libraries\\mbed\\common\\Ticker.cpp', 'mbed\\libraries\\mbed\\common\\Timeout.cpp', 'mbed\\libraries\\mbed\\common\\Timer.cpp', 'mbed\\libraries\\mbed\\common\\TimerEvent.cpp'], 'c': ['mbed\\libraries\\mbed\\common\\assert.c', 'mbed\\libraries\\mbed\\common\\board.c', 'mbed\\libraries\\mbed\\common\\error.c', 'mbed\\libraries\\mbed\\common\\exit.c', 'mbed\\libraries\\mbed\\common\\gpio.c', 'mbed\\libraries\\mbed\\common\\mbed_interface.c', 'mbed\\libraries\\mbed\\common\\pinmap_common.c', 'mbed\\libraries\\mbed\\common\\rtc_time.c', 'mbed\\libraries\\mbed\\common\\semihost_api.c', 'mbed\\libraries\\mbed\\common\\us_ticker_api.c', 'mbed\\libraries\\mbed\\common\\wait_api.c']}}, 'output_type': 'exe', 'mcu': '', 'project_dir': {'path': 'generated_projects', 'name': ''}, 'source_files_obj': [], 'target': 'mbed-lpc1768'}
DEBUG:root:Mcu definitions: {'Device': {'manufacturerId': 7, 'chipName': 'LPC1768', 'chipId': 165, 'manufacturerName': 'NXP'}, 'DebugOption': {'defaultAlgorithm': 'lpc17xx_512.elf'}, 'MemoryAreas': {'IROM2': {'startValue': 0, 'size': 0}, 'IRAM1': {'startValue': 268435456, 'size': 32768}, 'IRAM2': {'startValue': 537378816, 'size': 32768}, 'IROM1': {'startValue': 0, 'size': 524288}}}
DEBUG:root:Generating: generated_projects\coide_lpc1768_blinky\lpc1768_blinky.coproj

```