### PR TITLE
Dev output dir

### DIFF
--- a/project_generator/exporters/coide.py
+++ b/project_generator/exporters/coide.py
@@ -112,7 +112,7 @@ class CoideExporter(Exporter):
         expanded_dic['groups'] = {}
         for group in groups:
             expanded_dic['groups'][group] = []
-        dest = self.get_dest_path(expanded_dic, "coide", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
+        dest = self.get_dest_path(expanded_dic, env_settings, "coide", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
         self.iterate(data, expanded_dic, dest['rel_path'])
         self.fix_paths(expanded_dic, dest['rel_path'])
 

--- a/project_generator/exporters/exporter.py
+++ b/project_generator/exporters/exporter.py
@@ -17,7 +17,6 @@ import logging
 from os.path import join, dirname
 from jinja2 import Template, StrictUndefined
 
-
 class Exporter:
 
     """Just a template for subclassing"""
@@ -25,23 +24,31 @@ class Exporter:
     TEMPLATE_DIR = join(dirname(__file__), '..','templates')
     DOT_IN_RELATIVE_PATH = False
 
-    def get_dest_path(self, data, tool, destination, dir_name):
+    def get_dest_path(self, data, env_settings, tool, destination, dir_name):
         dest = {
             'dest_path' : '',
             'rel_path' : '',
         }
-        if destination is '':
-            destination = 'generated_projects'
-        if not os.path.exists(destination):
-            os.makedirs(destination)
-        if dir_name is '':
-            dir_name = tool + '_' + data['name']
-        project_dir = join(destination, dir_name)
-        # else:
-        #     project_dir=destination
+
+        # either output dir for all projects, or separate dir
+        if env_settings.generated_projects_dir != env_settings.generated_projects_dir_default:
+            # replace keywords
+            project_dir = env_settings.generated_projects_dir
+            project_dir = project_dir.replace('$tool$', tool)
+            project_dir = project_dir.replace('$project_name$', data['name'])
+            if data['target']:
+                project_dir = project_dir.replace('$target$', data['target'])
+        else:
+            if destination is '':
+                destination = 'generated_projects'
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+            if dir_name is '':
+                dir_name = tool + '_' + data['name']
+            project_dir = join(destination, dir_name)
+
         if not os.path.exists(project_dir):
             os.makedirs(project_dir)
-        # target_path = join(project_dir, target_file)
 
         # Get number of how far we are from root, to set paths in the project
         # correctly

--- a/project_generator/exporters/exporter.py
+++ b/project_generator/exporters/exporter.py
@@ -52,8 +52,11 @@ class Exporter:
 
         # Get number of how far we are from root, to set paths in the project
         # correctly
-        # path_from_root, filename = os.path.split(target_path)
-        count = len(os.path.split(project_dir))
+        count = 1
+        pdir = project_dir
+        while os.path.split(pdir)[0]:
+            pdir = os.path.split(pdir)[0]
+            count += 1
         rel_path_output = ''
 
         dest['rel_count'] = count

--- a/project_generator/exporters/gccarm.py
+++ b/project_generator/exporters/gccarm.py
@@ -83,9 +83,9 @@ class MakefileGccArmExporter(Exporter):
             for k, v in dic.items():
                 self.linker_options(k, v, data)
 
-    def fix_paths(self, data, name):
+    def fix_paths(self, data, name, env_settings):
         # get relative path and fix all paths within a project
-        data.update(self.get_dest_path(data, name, data['project_dir']['path'], data['project_dir']['name']))
+        data.update(self.get_dest_path(data, env_settings, name, data['project_dir']['path'], data['project_dir']['name']))
         fixed_paths = []
         for path in data['include_paths']:
             fixed_paths.append(join(data['rel_path'], normpath(path)))
@@ -112,7 +112,7 @@ class MakefileGccArmExporter(Exporter):
         return project_path, [makefile]
 
     def process_data_for_makefile(self, data, env_settings, name):
-        self.fix_paths(data, name)
+        self.fix_paths(data, name, env_settings)
         self.list_files(data, 'source_files_c', data['rel_path'])
         self.list_files(data, 'source_files_cpp', data['rel_path'])
         self.list_files(data, 'source_files_s', data['rel_path'])

--- a/project_generator/exporters/gdb.py
+++ b/project_generator/exporters/gdb.py
@@ -29,7 +29,7 @@ class ARMNoneEABIGDBExporter(GDBExporter):
         # !!! TODO: store and read settings from gdb_definitions
         expanded_dic['gdb_server_port'] = 3333
 
-        dest = self.get_dest_path(expanded_dic, "gdb", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
+        dest = self.get_dest_path(expanded_dic, env_settings, "gdb", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
 
         project_path, startupfile = self.gen_file(
             'gdb.tmpl', expanded_dic, '%s.gdbstartup' % data['name'], dest['dest_path'])

--- a/project_generator/exporters/iar.py
+++ b/project_generator/exporters/iar.py
@@ -123,7 +123,7 @@ class IAREWARMExporter(Exporter):
         expanded_dic['groups'] = {}
         for group in groups:
             expanded_dic['groups'][group] = []
-        dest = self.get_dest_path(expanded_dic, "iar", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
+        dest = self.get_dest_path(expanded_dic, env_settings, "iar", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
         self.iterate(data, expanded_dic, dest['rel_path'])
         self.fix_paths(expanded_dic, dest['rel_path'])
 

--- a/project_generator/exporters/uvision.py
+++ b/project_generator/exporters/uvision.py
@@ -163,7 +163,7 @@ class UvisionExporter(Exporter):
         for group in groups:
             expanded_dic['groups'][group] = []
         # get relative path and fix all paths within a project
-        dest = self.get_dest_path(expanded_dic, "uvision", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
+        dest = self.get_dest_path(expanded_dic, env_settings, "uvision", expanded_dic['project_dir']['path'], expanded_dic['project_dir']['name'])
         self.iterate(data, expanded_dic, dest['rel_path'])
         self.fix_paths(expanded_dic, dest['rel_path'])
 

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -333,7 +333,7 @@ class Project:
         tool_specific_settings = []
         toolnames = self.tools.get_value(tool, 'toolnames')
         for tool_spec in toolnames:
-            if tool != tool_spec:
+            if self.tools.get_value(tool, 'toolchain') != tool_spec:
                 tool_specific_settings.append(self.tool_specific[tool_spec])
 
         d = {
@@ -364,7 +364,7 @@ class Project:
                                 list(flatten([settings.all_sources_of_type('lib') for settings in tool_specific_settings])) +
                                 toolchain_specific_settings.all_sources_of_type('lib'),
             'linker_file': self.linker_file
-                        or toolchain_specific_settings.linker_file,
+                        or toolchain_specific_settings.linker_file or [tool_settings.linker_file for tool_settings in tool_specific_settings if tool_settings][0],
             'macros': self.macros +
                       list(flatten([ settings.macros for settings in tool_specific_settings])) +
                       toolchain_specific_settings.macros,

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -236,7 +236,7 @@ class Project:
             self.include_paths = source_paths
 
         if self.project_dir['path'] == '':
-            self.project_dir['path'] = self.workspace.settings.generated_projects_folder
+            self.project_dir['path'] = self.workspace.settings.generated_projects_dir_default
 
     def _process_source_files(self, files, group_name):
         source_paths = []

--- a/project_generator/project.py
+++ b/project_generator/project.py
@@ -364,7 +364,7 @@ class Project:
                                 list(flatten([settings.all_sources_of_type('lib') for settings in tool_specific_settings])) +
                                 toolchain_specific_settings.all_sources_of_type('lib'),
             'linker_file': self.linker_file
-                        or toolchain_specific_settings.linker_file or [tool_settings.linker_file for tool_settings in tool_specific_settings if tool_settings][0],
+                        or toolchain_specific_settings.linker_file or [tool_settings.linker_file for tool_settings in tool_specific_settings if tool_settings.linker_file][0],
             'macros': self.macros +
                       list(flatten([ settings.macros for settings in tool_specific_settings])) +
                       toolchain_specific_settings.macros,

--- a/project_generator/settings.py
+++ b/project_generator/settings.py
@@ -21,7 +21,8 @@ GCC_BIN_PATH
 """
 
 import os
-from os.path import expanduser
+from os.path import expanduser, normpath
+
 import yaml
 
 from os.path import join, pardir, sep
@@ -44,7 +45,8 @@ class ProjectSettings:
         self.paths['definitions'] = join(expanduser('~/.pg'), 'definitions')
         if not os.path.exists(join(expanduser('~/.pg'))):
             os.mkdir(join(expanduser('~/.pg')))
-        self.generated_projects_folder = 'generated_projects'
+        self.generated_projects_dir_default = 'generated_projects'
+        self.generated_projects_dir = self.generated_projects_dir_default
 
     def update(self, settings):
         if 'tools' in settings:
@@ -52,10 +54,10 @@ class ProjectSettings:
                 if k in self.paths:
                     self.paths[k] = v['path'][0]
         if 'definitions_dir' in settings:
-            self.paths['definitions'] = settings['definitions_dir'][0]
+            self.paths['definitions'] = normpath(settings['definitions_dir'][0])
 
-        if 'generated_projects_folder' in settings:
-            self.generated_projects_folder = settings['generated_projects_folder'][0]
+        if 'export_dir' in settings:
+            self.generated_projects_dir = normpath(settings['export_dir'][0])
 
     def set_definitions_file(self, def_dir):
         self.paths['definitions'] = def_dir

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,1 +1,1 @@
-git clone https://github.com/matthewelse/project_generator_tests.git test_projects
+git clone https://github.com/project-generator/project_generator_tests.git test_projects

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -26,7 +26,7 @@ class TestWorkspace(TestCase):
     def test_settings(self):
         # only check things which are affected by projects.yaml
         assert self.workspace.settings.paths['definitions'] == '~/.notpg'
-        assert self.workspace.settings.generated_projects_folder == 'not_generated_projects'
+        assert self.workspace.settings.generated_projects_dir == 'not_generated_projects'
 
     # def test_load_definitions(self):
     #     self.workspace.load_definitions()


### PR DESCRIPTION
So far got 3 keywords for this path, target, project name and tool. It is hardcoded in the export, but should probably become own class on its own as this, as this feature might be used in other context. 

```
settings:
    export_dir:
        - generated_projects/$target$/$project_name$/$tool$
```

@sg- Please test